### PR TITLE
Extract pairs and singles from diginorm

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,12 +35,17 @@ params {
         'diginorm_normalizebymedian' {
             args                = ''
             publish_dir         = 'diginorm'
-            publish_files       = ['.fastq.gz':'']
+            publish_files       = ['.fastq.gz':'', '.log':'logs']
         }
         'diginorm_filterabund' {
             args                = '--variable-coverage'
             publish_dir         = 'diginorm'
-            publish_files       = ['.fastq.gz':'']
+            publish_files       = ['.fastq.gz':'', '.log':'logs']
+        }
+        'diginorm_extractpairedreads' {
+            args                = ''
+            publish_dir         = 'diginorm'
+            publish_files       = ['.fastq.gz':'', '.log':'logs']
         }
         'megahit' {
             args                = ''

--- a/modules/local/khmer/filterabund.nf
+++ b/modules/local/khmer/filterabund.nf
@@ -24,6 +24,7 @@ process KHMER_FILTERABUND {
 
     output:
     path "${name}.fa.fastq.gz", emit: reads
+    path "${name}.fa.log"     , emit: log
     path "versions.yml"       , emit: versions
 
     script:
@@ -35,7 +36,7 @@ process KHMER_FILTERABUND {
         ${options.args} \\
         -o ${name}.fa.fastq.gz \\
         ${reads} \\
-        ${graph}
+        ${graph} 2>&1 | tee ${name}.fa.log
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:

--- a/modules/local/megahit/interleaved.nf
+++ b/modules/local/megahit/interleaved.nf
@@ -20,6 +20,7 @@ process MEGAHIT_INTERLEAVED {
 
     input:
     path intl_pe_reads
+    path se_reads
     val  assembly
 
     output:
@@ -31,10 +32,12 @@ process MEGAHIT_INTERLEAVED {
     path "versions.yml"                                            , emit: versions
 
     script:
+    single_ends = se_reads ? "-r ${se_reads.join(',')}" : ""
     
     """
     megahit \\
         --12 ${intl_pe_reads.join(',')} \\
+        ${single_ends} \\
         -t $task.cpus \\
         $options.args \\
         --out-prefix $assembly

--- a/subworkflows/local/diginorm.nf
+++ b/subworkflows/local/diginorm.nf
@@ -4,9 +4,11 @@
 
 params.diginorm_normalizebymedian_options       = [:]
 params.diginorm_filterabund_options             = [:]
+params.diginorm_extractpairedreads_options      = [:]
 
-include { KHMER_NORMALIZEBYMEDIAN } from '../../modules/local/khmer/normalizebymedian' addParams( options: params.diginorm_normalizebymedian_options )
-include { KHMER_FILTERABUND       } from '../../modules/local/khmer/filterabund'       addParams( options: params.diginorm_filterabund_options )
+include { KHMER_NORMALIZEBYMEDIAN  } from '../../modules/local/khmer/normalizebymedian'  addParams( options: params.diginorm_normalizebymedian_options )
+include { KHMER_FILTERABUND        } from '../../modules/local/khmer/filterabund'        addParams( options: params.diginorm_filterabund_options )
+include { KHMER_EXTRACTPAIREDREADS } from '../../modules/local/khmer/extractpairedreads' addParams( options: params.diginorm_extractpairedreads_options )
 
 workflow DIGINORM {
     take:
@@ -23,7 +25,11 @@ workflow DIGINORM {
     KHMER_FILTERABUND(KHMER_NORMALIZEBYMEDIAN.out.reads, KHMER_NORMALIZEBYMEDIAN.out.graph, "${name}.nm")
     ch_versions = ch_versions.mix(KHMER_FILTERABUND.out.versions)
 
+    KHMER_EXTRACTPAIREDREADS(KHMER_FILTERABUND.out.reads, "${name}.nm.fa")
+    ch_versions = ch_versions.mix(KHMER_EXTRACTPAIREDREADS.out.versions)
+
     emit:
-    reads    = KHMER_FILTERABUND.out.reads
+    pairs    = KHMER_EXTRACTPAIREDREADS.out.pairs
+    singles  = KHMER_EXTRACTPAIREDREADS.out.singles
     versions = ch_versions
 }

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -140,15 +140,21 @@ workflow METATDENOVO {
     if ( params.diginorm ) {
         DIGINORM(SEQTK_MERGEPE.out.reads.collect { meta, fastq -> fastq }, [], 'all_samples')
         ch_versions = ch_versions.mix(SEQTK_MERGEPE.out.versions)
-        ch_reads_to_assembly = DIGINORM.out.pairs
+        ch_pe_reads_to_assembly = DIGINORM.out.pairs
+        ch_se_reads_to_assembly = DIGINORM.out.singles
     } else {
-        ch_reads_to_assembly = SEQTK_MERGEPE.out.reads.map { meta, fastq -> fastq }
+        ch_pe_reads_to_assembly = SEQTK_MERGEPE.out.reads.map { meta, fastq -> fastq }
+        ch_se_reads_to_assembly = []
     }
 
     //
     // MODULE: Run Megahit on all interleaved fastq files
     //
-    MEGAHIT_INTERLEAVED(ch_reads_to_assembly.collect(), 'all_samples')
+    MEGAHIT_INTERLEAVED(
+        ch_pe_reads_to_assembly.collect(), 
+        ch_se_reads_to_assembly.collect(), 
+        'all_samples'
+    )
     ch_versions = ch_versions.mix(MEGAHIT_INTERLEAVED.out.versions)
 
 //    //

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -52,14 +52,16 @@ include { FASTQC_TRIMGALORE } from '../subworkflows/local/fastqc_trimgalore' add
 //
 // SUBWORKFLOW: Perform digital normalization
 //
-def diginorm_normalizebymedian_options   = modules['diginorm_normalizebymedian']
-diginorm_normalizebymedian_options.args += Utils.joinModuleArgs(["-C ${params.diginorm_C} -k ${params.diginorm_k}"])
-def diginorm_filterabund_options         = modules['diginorm_filterabund']
-diginorm_filterabund_options.args       += Utils.joinModuleArgs(["-C ${params.diginorm_C} -Z ${params.diginorm_C}"])
+def diginorm_normalizebymedian_options    = modules['diginorm_normalizebymedian']
+diginorm_normalizebymedian_options.args  += Utils.joinModuleArgs(["-C ${params.diginorm_C} -k ${params.diginorm_k}"])
+def diginorm_filterabund_options          = modules['diginorm_filterabund']
+diginorm_filterabund_options.args        += Utils.joinModuleArgs(["-C ${params.diginorm_C} -Z ${params.diginorm_C}"])
+def diginorm_extractpairedreads_options   = modules['diginorm_extractpairedreads']
 
 include { DIGINORM } from '../subworkflows/local/diginorm' addParams(
-    diginorm_normalizebymedian_options: diginorm_normalizebymedian_options, 
-    diginorm_filterabund_options: diginorm_filterabund_options
+    diginorm_normalizebymedian_options:  diginorm_normalizebymedian_options, 
+    diginorm_filterabund_options:        diginorm_filterabund_options,
+    diginorm_extractpairedreads_options: diginorm_extractpairedreads_options
 )
 
 /*
@@ -138,7 +140,7 @@ workflow METATDENOVO {
     if ( params.diginorm ) {
         DIGINORM(SEQTK_MERGEPE.out.reads.collect { meta, fastq -> fastq }, [], 'all_samples')
         ch_versions = ch_versions.mix(SEQTK_MERGEPE.out.versions)
-        ch_reads_to_assembly = DIGINORM.out.reads
+        ch_reads_to_assembly = DIGINORM.out.pairs
     } else {
         ch_reads_to_assembly = SEQTK_MERGEPE.out.reads.map { meta, fastq -> fastq }
     }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

`filter-abund.py` left orphaned single end reads and output a mix of pe and se. 

1. Call `extract-paired-reads.py` to separate the two.
2. Add single ends as non-mandatory input to the `MEGAHIT_INTERLEAVED` module.