### PR TITLE
eukulele gtdb call

### DIFF
--- a/modules/local/eukulele/main.nf
+++ b/modules/local/eukulele/main.nf
@@ -2,10 +2,10 @@ process EUKULELE {
     tag "$meta.id"
     label 'process_high'
 
-    conda (params.enable_conda ? "bioconda::eukulele=2.0.2-0" : null)
+    conda (params.enable_conda ? "bioconda::eukulele=2.0.3" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/eukulele:2.0.2--pyh723bec7_0' :
-        'quay.io/biocontainers/eukulele:2.0.2--pyh723bec7_0' }"
+        'https://depot.galaxyproject.org/singularity/eukulele:2.0.3--pyh723bec7_0' :
+        'quay.io/biocontainers/eukulele:2.0.3--pyh723bec7_0' }"
 
     input:
     tuple val(meta), path(contigs_fasta)

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,7 +28,7 @@ params {
     eggnog_dbpath               = "./eggnog/"
 
     // eukulele
-    eukulele_db                 = 'phylodb'
+    eukulele_db                 = null
     skip_eukulele               = false
     eukulele_dbpath             = './eukulele'
     eukulele_method             = 'mets'


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

Hi,
I discovered that inside the nextflow pipeline, EUKulele is acting differently as outside. When I run the pipeline with gtdb path, EUKulele doesn't recognise the path and start to download a new database as default (e.g. PhyloDB). We should try do avoid this and make it work properly.
when I run EUKuele with gtdb I use this command line:

EUKulele --m mets --sample_dir contigs --reference_dir gtdb/ -o output

the EUKulele version that I use in the command line is 2.0.2 while the one in nf-core module is 2.0.3 I don't know if this affects the performance of the program. 
