### PR TITLE
Add an eggnog summary for statistics

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -296,7 +296,7 @@ process {
         publishDir = [
         path: { "${params.outdir}/summary_tables" },
         mode: 'copy',
-        pattern: "eggnogs.tsv.gz"
+        pattern: "eggnog_summary.tsv"
         ]
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -284,6 +284,14 @@ process {
         ]
     }
 
+    withName: SUM_EGGNOG {
+        publishDir = [
+        path: { "${params.outdir}/summary_tables" },
+        mode: 'copy',
+        pattern: "eggnogs.tsv.gz"
+        ]
+    }
+
     withName: EUKULELE_DOWNLOAD {
         ext.when = { db }
         publishDir = [
@@ -292,7 +300,6 @@ process {
             pattern: "*"
         ]
     }
-
 
     withName: EUKULELE {
         publishDir = [

--- a/modules/local/sum_eggnog.nf
+++ b/modules/local/sum_eggnog.nf
@@ -27,8 +27,6 @@ process SUM_EGGNOG {
     """
     #!/usr/bin/env Rscript
 
-    library(data.table)
-    library(dtplyr)
     library(dplyr)
     library(readr)
     library(tidyr)

--- a/modules/local/sum_eggnog.nf
+++ b/modules/local/sum_eggnog.nf
@@ -40,7 +40,7 @@ process SUM_EGGNOG {
 
     counts <- list.files(pattern = "*_counts.tsv.gz") %>%
         map_df(~read_tsv(.,  show_col_types  = TRUE)) %>%
-            as_tibble()
+        as_tibble()
 
     counts %>% select(1, 7) %>%
         right_join(eggnog, by = 'orf') %>%

--- a/modules/local/sum_eggnog.nf
+++ b/modules/local/sum_eggnog.nf
@@ -1,0 +1,59 @@
+process SUM_EGGNOG {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "conda-forge::r-tidyverse=1.3.1 conda-forge::r-data.table=1.14.0 conda-forge::r-dtplyr=1.1.0" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    'https://depot.galaxyproject.org/singularity/mulled-v2-508c9bc5e929a77a9708902b1deca248c0c84689:0bb5bee2557136d28549f41d3faa08485e967aa1-0' :
+    'quay.io/biocontainers/mulled-v2-508c9bc5e929a77a9708902b1deca248c0c84689:0bb5bee2557136d28549f41d3faa08485e967aa1-0' } "
+
+    input:
+
+    tuple val(meta), path(fcs)), path(eggnog)
+
+    output:
+
+    path "${meta.id}_eggnog_stats.tsv", emit: overall_stats
+    path "versions.yml"               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    #!/usr/bin/env Rscript
+
+library(data.table)
+library(dtplyr)
+library(dplyr)
+library(readr)
+library(tidyr)
+library(stringr)
+library(tidyverse)
+
+    TYPE_ORDER = c('sample', 'database', 'field', 'value')
+    # call the tables into variables
+    eggnog <- fread("eggnogs.tsv.gz")
+    counts <- list.files(pattern = "*_counts.tsv.gz") %>%
+            map_df(~fread(.))
+
+    counts[,c(1,6)] %>%
+        right_join(eggnog[,1], by = 'orf') %>%
+        drop_na() %>%
+        group_by(sample) %>%
+        count(orf) %>%
+        summarise( value = sum(n)) %>%
+        as_tibble() %>%
+        add_column(database = "eggnog", field = "n_orfs") %>%
+        relocate(value, .after = last_col()) %>%
+        write_tsv('eggnog_summary.tsv')
+
+    writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")), paste0("    dplyr: ", packageVersion('dplyr')),
+        paste0("    dtplyr: ", packageVersion('dtplyr')), paste0("    data.table: ", packageVersion('data.table')), paste0("    readr: ", packageVersion('readr')),
+        paste0("    purrr: ", packageVersion('purrr')), paste0("    tidyr: ", packageVersion('tidyr')), paste0("    stringr: ", packageVersion('stringr')) ),
+        "versions.yml")
+    """
+}

--- a/modules/local/sum_eggnog.nf
+++ b/modules/local/sum_eggnog.nf
@@ -39,7 +39,7 @@ process SUM_EGGNOG {
     # call the tables into variables
     eggnog <- read.delim("eggnogs.tsv.gz",  sep = "\t", header = TRUE, fill = TRUE) %>%
         as_tibble()
- 
+
     counts <- list.files(pattern = "*_counts.tsv.gz") %>%
             map_df(~read.table(.,  sep = "\t", header = TRUE, fill = TRUE)) %>%
             as_tibble()

--- a/modules/local/sum_eggnog.nf
+++ b/modules/local/sum_eggnog.nf
@@ -9,7 +9,8 @@ process SUM_EGGNOG {
 
     input:
 
-    tuple val(meta), path(fcs)), path(eggnog)
+    tuple val(meta), path(eggnog)
+    path(fcs)
 
     output:
 

--- a/modules/local/sum_eggnog.nf
+++ b/modules/local/sum_eggnog.nf
@@ -37,21 +37,17 @@ process SUM_EGGNOG {
 
     TYPE_ORDER = c('sample', 'database', 'field', 'value')
     # call the tables into variables
-    eggnog <- read.delim("eggnogs.tsv.gz",  sep = "\t", header = TRUE, fill = TRUE) %>%
+    eggnog <- read.tsv("eggnogs.tsv.gz",  sep = "\t", header = TRUE, fill = TRUE) %>%
         as_tibble()
 
-    counts <- list.files(pattern = "*_counts.tsv.gz") %>%
-            map_df(~read.table(.,  sep = "\t", header = TRUE, fill = TRUE)) %>%
+    counts <- read_tsv("*_counts.tsv.gz", show_col_types = FALSE) %>%
             as_tibble()
 
-    counts[,c(1,7)] %>%
-        right_join(eggnog[,1], by = 'orf') %>%
-        drop_na() %>%
-        as_tibble() %>%
+    counts %>% select(1, 7) %>%
+        right_join(eggnog, by = 'orf') %>%
         group_by(sample) %>%
         count(orf) %>%
-        summarise( value = sum(n)) %>%
-        as_tibble() %>%
+        summarise( value = sum(n), groups = 'drop') %>%
         add_column(database = "eggnog", field = "n_orfs") %>%
         relocate(value, .after = last_col()) %>%
         write_tsv('eggnog_summary.tsv')

--- a/modules/local/sum_eggnog.nf
+++ b/modules/local/sum_eggnog.nf
@@ -37,10 +37,11 @@ process SUM_EGGNOG {
 
     TYPE_ORDER = c('sample', 'database', 'field', 'value')
     # call the tables into variables
-    eggnog <- read.tsv("eggnogs.tsv.gz",  sep = "\t", header = TRUE, fill = TRUE) %>%
+    eggnog <- read_tsv("eggnogs.tsv.gz", show_col_types = FALSE ) %>%
         as_tibble()
 
-    counts <- read_tsv("*_counts.tsv.gz", show_col_types = FALSE) %>%
+    counts <- list.files(pattern = "*_counts.tsv.gz") %>%
+        map_df(~read_tsv(.,  show_col_types  = TRUE)) %>%
             as_tibble()
 
     counts %>% select(1, 7) %>%

--- a/modules/local/sum_eggnog.nf
+++ b/modules/local/sum_eggnog.nf
@@ -44,16 +44,17 @@ process SUM_EGGNOG {
             map_df(~read.table(.,  sep = "\t", header = TRUE, fill = TRUE)) %>%
             as_tibble()
 
-    #counts[,c(1,7)] %>%
-        #right_join(eggnog[,1], by = 'orf') %>%
-        #drop_na() %>%
-        #group_by(sample) %>%
-        #count(orf) %>%
-        #summarise( value = sum(n)) %>%
-        #as_tibble() %>%
-        #add_column(database = "eggnog", field = "n_orfs") %>%
-        #relocate(value, .after = last_col()) %>%
-        write_tsv(counts, 'eggnog_summary.tsv')
+    counts[,c(1,7)] %>%
+        right_join(eggnog[,1], by = 'orf') %>%
+        drop_na() %>%
+        as_tibble() %>%
+        group_by(sample) %>%
+        count(orf) %>%
+        summarise( value = sum(n)) %>%
+        as_tibble() %>%
+        add_column(database = "eggnog", field = "n_orfs") %>%
+        relocate(value, .after = last_col()) %>%
+        write_tsv('eggnog_summary.tsv')
 
     writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")), paste0("    dplyr: ", packageVersion('dplyr')),
         paste0("    dtplyr: ", packageVersion('dtplyr')), paste0("    data.table: ", packageVersion('data.table')), paste0("    readr: ", packageVersion('readr')),

--- a/subworkflows/local/eggnog.nf
+++ b/subworkflows/local/eggnog.nf
@@ -5,11 +5,12 @@
 include { EGGNOG_DOWNLOAD } from '../../modules/local/eggnog/download'
 include { EGGNOG_MAPPER   } from '../../modules/local/eggnog/mapper'
 include { EGGNOG_TABLE    } from '../../modules/local/eggnog_table'
+include { SUM_EGGNOG      } from '../../modules/local/sum_eggnog.nf'
 
 workflow EGGNOG {
     take:
         faa
-
+        collect_fcs
     main:
         ch_versions = Channel.empty()
 
@@ -23,24 +24,29 @@ workflow EGGNOG {
             EGGNOG_DOWNLOAD()
             EGGNOG_MAPPER(faa, EGGNOG_DOWNLOAD.out.db)
             EGGNOG_TABLE(EGGNOG_MAPPER.out.annotations)
+            SUM_EGGNOG(EGGNOG_TABLE.out.eggtab, collect_fcs )
         } else {
             if (! test.exists()){
                 EGGNOG_DOWNLOAD()
                 EGGNOG_MAPPER(faa, EGGNOG_DOWNLOAD.out.db)
                 EGGNOG_TABLE(EGGNOG_MAPPER.out.annotations)
+                SUM_EGGNOG(EGGNOG_TABLE.out.eggtab, collect_fcs )
             }  else {
             ch_dbpath = Channel.fromPath(params.eggnog_dbpath)
             EGGNOG_MAPPER(faa, ch_dbpath)
             EGGNOG_TABLE(EGGNOG_MAPPER.out.annotations)
+            SUM_EGGNOG(EGGNOG_TABLE.out.eggtab, collect_fcs )
             }
         }
 
         ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
         ch_versions = ch_versions.mix(EGGNOG_TABLE.out.versions)
+        ch_versions = ch_versions.mix(SUM_EGGNOG.out.versions)
 
     emit:
-        hits     = EGGNOG_MAPPER.out.hits
-        eggtab   = EGGNOG_TABLE.out.eggtab
-        versions = ch_versions
+        hits              = EGGNOG_MAPPER.out.hits
+        formateggnogtable = EGGNOG_TABLE.out.eggtab
+        versions          = ch_versions
+        sumtable          = SUM_EGGNOG.out.eggnog_summary
 
 }

--- a/subworkflows/local/eggnog.nf
+++ b/subworkflows/local/eggnog.nf
@@ -40,6 +40,7 @@ workflow EGGNOG {
 
     emit:
         hits     = EGGNOG_MAPPER.out.hits
+        eggtab   = EGGNOG_TABLE.out.eggtab
         versions = ch_versions
 
 }

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -92,7 +92,6 @@ include { UNPIGZ as UNPIGZ_EUKULELE        } from '../modules/local/unpigz.nf'
 include { UNPIGZ as UNPIGZ_CONTIGS         } from '../modules/local/unpigz.nf'
 include { COLLECT_FEATURECOUNTS            } from '../modules/local/collect_featurecounts.nf'
 include { COLLECT_STATS                    } from '../modules/local/collect_stats.nf'
-include { SUM_EGGNOG                       } from '../modules/local/sum_eggnog.nf'
 
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
@@ -407,8 +406,9 @@ workflow METATDENOVO {
         .set { ch_collect_feature }
 
     COLLECT_FEATURECOUNTS ( ch_collect_feature )
-    ch_versions = ch_versions.mix(COLLECT_FEATURECOUNTS.out.versions)
-    ch_fcs = COLLECT_FEATURECOUNTS.out.counts.collect { it[1]}.map { [ it ] }
+    ch_versions           = ch_versions.mix(COLLECT_FEATURECOUNTS.out.versions)
+    ch_fcs                = COLLECT_FEATURECOUNTS.out.counts.collect { it[1]}.map { [ it ] }
+    ch_fcs_eggnog         = COLLECT_FEATURECOUNTS.out.counts.map { it[1]}
     ch_collect_stats
         .combine(ch_fcs)
         .set { ch_collect_stats }
@@ -418,9 +418,8 @@ workflow METATDENOVO {
     //
 
     if (params.eggnog) {
-        EGGNOG(ch_aa)
+        EGGNOG(ch_aa, ch_fcs_eggnog )
         ch_versions = ch_versions.mix(EGGNOG.out.versions)
-        SUM_EGGNOG(EGGNOG.out.eggtab, COLLECT_FEATURECOUNTS.out.counts.map { it[1]} )
     }
     //
     // MODULE: Collect statistics from mapping analysis

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -401,7 +401,7 @@ workflow METATDENOVO {
     if (params.eggnog) {
         EGGNOG(ch_aa)
         ch_versions = ch_versions.mix(EGGNOG.out.versions)
-        SUM_EGGNOG(EGGNOG.out.eggtab.map, ch_fcs)
+        SUM_EGGNOG(EGGNOG.out.eggtab, COLLECT_FEATURECOUNTS.out.counts.map { it[1]} )
     }
     //
     // MODULE: Collect statistics from mapping analysis


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).


This is just one of several PRs with the goal to have a final table from `collect_stats.nf` module that will include the proportion of orf annotated with the different annotation programs. this PR is for `sum_eggnog.nf` and it is not integrated yet in `collect_stats.nf`. ( I prefer to wait and having at least the summary from `eukulele`, then I can combine all the tables in one).