### PR TITLE
Format spades output with a new module

### DIFF
--- a/modules/local/format_prodigal.nf
+++ b/modules/local/format_prodigal.nf
@@ -12,7 +12,7 @@ process FORMAT_PRODIGAL {
 
     output:
     tuple val(meta), path("${gff}.gz"), emit: format_gff
-    path "versions.yml"             , emit: versions
+    path "versions.yml"               , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/formatspades.nf
+++ b/modules/local/formatspades.nf
@@ -1,0 +1,33 @@
+process FORMATSPADES {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "bioconda::gzip=1.11"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gzip:1.11':
+        'quay.io/biocontainers/gzip:1.11' }"
+
+    input:
+    tuple val(meta), path(assembly)
+
+    output:
+    tuple val(meta), path("rnaspades.format_header.transcript.fa.gz") , emit: assembly
+    path "versions.yml"                                               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    cp $assembly rnaspades.fa.gz
+    gunzip -c rnaspades.fa.gz  | sed 's/>NODE_\\([0-9]*\\).*/>NODE_\\1/g' | gzip > rnaspades.format_header.transcript.fa.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        formatspades: \$( echo \$(gzip --version 2>&1)| sed 's/.* gzip//')
+    END_VERSIONS
+    """
+}

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -92,6 +92,7 @@ include { UNPIGZ as UNPIGZ_EUKULELE        } from '../modules/local/unpigz.nf'
 include { UNPIGZ as UNPIGZ_CONTIGS         } from '../modules/local/unpigz.nf'
 include { COLLECT_FEATURECOUNTS            } from '../modules/local/collect_featurecounts.nf'
 include { COLLECT_STATS                    } from '../modules/local/collect_stats.nf'
+include { FORMATSPADES                     } from '../modules/local/formatspades.nf'
 
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
@@ -292,9 +293,10 @@ workflow METATDENOVO {
             WRITESPADESYAML.out.yaml,
             []
         )
-        ch_assembly_contigs = SPADES.out.transcripts
-
+        ch_assembly = SPADES.out.transcripts
         ch_versions = ch_versions.mix(SPADES.out.versions)
+        FORMATSPADES( ch_assembly )
+        ch_assembly_contigs = FORMATSPADES.out.assembly
     } else if ( params.assembler == MEGAHIT ) {
         MEGAHIT_INTERLEAVED(
             ch_pe_reads_to_assembly.collect().ifEmpty([]),


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

I added a new module `format spades.nf` that parses the output form `rnaspades`. `Prokka` doesn't complain anymore and it is working with all the other orf callers. 
We can think whether we want SPADES modules as one sub workflow or not.