### PR TITLE
Make kofamscan use all cpus

### DIFF
--- a/modules/local/kofamscan/scan.nf
+++ b/modules/local/kofamscan/scan.nf
@@ -32,6 +32,7 @@ process KOFAMSCAN_SCAN {
         --profile $koprofiles \\
         --ko-list $ko_list \\
         --format detail-tsv \\
+        --cpu $task.cpus \\
         $input \\
         -o kofamscan_output.tsv
 


### PR DESCRIPTION
Add `--cpus` argument to the kofamscan module. *Not* tested :fearful:!