### PR TITLE
Contig length filter

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -78,7 +78,7 @@ process {
                 path : { "${params.outdir}/bbmap/bbnorm/"},
                 mode : 'copy',
                 pattern: "*.fastq.gz",
-                enabled: params.save_bam
+                enabled: params.save_bbnorm_fastq
             ]
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -114,6 +114,10 @@ process {
         ]
     }
 
+    withName: SEQTK_SEQ_CONTIG_FILTER {
+        ext.args = "-L ${params.min_contig_length}"
+    }
+
     withName: BBMAP_INDEX {
         publishDir = [
             enabled: false

--- a/modules.json
+++ b/modules.json
@@ -95,6 +95,11 @@
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
                         "installed_by": ["modules"]
                     },
+                    "seqtk/seq": {
+                        "branch": "master",
+                        "git_sha": "23e7fed6d975b0132cdd564c809a75e6c0215f05",
+                        "installed_by": ["modules"]
+                    },
                     "spades": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",

--- a/modules/nf-core/seqtk/seq/main.nf
+++ b/modules/nf-core/seqtk/seq/main.nf
@@ -1,0 +1,40 @@
+process SEQTK_SEQ {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::seqtk=1.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqtk:1.4--he4a0461_1' :
+        'biocontainers/seqtk:1.4--he4a0461_1' }"
+
+    input:
+    tuple val(meta), path(fastx)
+
+    output:
+    tuple val(meta), path("*.gz")     , emit: fastx
+    path "versions.yml"               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    def extension = "fastq"
+    if ("$fastx" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz/ || "$args" ==~ /\-[aA]/ ) {
+        extension = "fasta"
+    }
+    """
+    seqtk \\
+        seq \\
+        $args \\
+        $fastx | \\
+        gzip -c > ${prefix}.seqtk-seq.${extension}.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqtk: \$(echo \$(seqtk 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/seqtk/seq/meta.yml
+++ b/modules/nf-core/seqtk/seq/meta.yml
@@ -1,0 +1,44 @@
+name: seqtk_seq
+description: Common transformation operations on FASTA or FASTQ files.
+keywords:
+  - seq
+  - filter
+  - transformation
+tools:
+  - seqtk:
+      description: Seqtk is a fast and lightweight tool for processing sequences in the FASTA or FASTQ format. The seqtk seq command enables common transformation operations on FASTA or FASTQ files.
+      homepage: https://github.com/lh3/seqtk
+      documentation: https://docs.csc.fi/apps/seqtk/
+      tool_dev_url: https://github.com/lh3/seqtk
+      licence: ["MIT"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - sequences:
+      type: file
+      description: A FASTQ or FASTA file
+      pattern: "*.{fastq.gz, fastq, fq, fq.gz, fasta, fastq.gz, fa, fa.gz, fas, fas.gz, fna, fna.gz}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - sequences:
+      type: file
+      description: FASTQ/FASTA file containing renamed sequences
+      pattern: "*.{fastq.gz, fasta.gz}"
+
+authors:
+  - "@hseabolt"
+  - "@mjcipriano"
+  - "@sateeshperi"

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,6 +39,7 @@ params {
 
     // assembler option
     assembler                   = 'megahit'
+    min_contig_length           = 0
 
     // Mapping options
     save_bam                    = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,17 +28,20 @@ params {
     save_trimmed                = false
     skip_trimming               = false
 
-    // BBmap options
+    // BBDuk options
     sequence_filter             = null
-    save_bam                    = false
 
     // Digital normalization options
     bbnorm                      = false
     bbnorm_target               = 100
     bbnorm_min                  = 5
+    save_bbnorm_fastq           = false
 
     // assembler option
     assembler                   = 'megahit'
+
+    // Mapping options
+    save_bam                    = false
 
     // orf caller options
     orf_caller                  = 'prodigal'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -143,7 +143,7 @@
                 "bbnorm_target": {
                     "type": "integer",
                     "default": 100,
-                    "description": "produce an output file of reads with an average depth of nx. ",
+                    "description": "Reduce the number of reads for assembly average coverage of this number.",
                     "fa_icon": "fas fa-align-justify"
                 },
                 "bbnorm_min": {
@@ -178,6 +178,12 @@
                     "mimetype": "text/plain",
                     "description": "Path to a fasta file with a finished assembly. Assembly will be skipped by the pipeline.",
                     "fa_icon": "far fa-file-code"
+                },
+                "min_contig_length": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Filter out contigs shorter than this.",
+                    "fa_icon": "fas fa-align-justify"
                 }
             },
             "fa_icon": "fas fa-bezier-curve"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -24,7 +24,7 @@
                 },
                 "se_reads": {
                     "type": "boolean",
-                    "default": "false",
+                    "default": false,
                     "description": "activate when using single end reads input"
                 },
                 "outdir": {
@@ -113,7 +113,7 @@
             "description": "all the trim option are listed below"
         },
         "bbnorm_options": {
-            "title": "BBnorm options",
+            "title": "Filtering options",
             "type": "object",
             "description": "",
             "default": "",
@@ -123,11 +123,6 @@
                     "description": "Fasta file with sequences to filter away before running assembly etc..",
                     "help_text": "Read sequences matching this file will be filtered out from samples with BBDuk before mapping. If no file is specified, BBDuk will not be run.",
                     "fa_icon": "fas fa-filter"
-                },
-                "save_bam": {
-                    "type": "boolean",
-                    "description": "save the output from BBMap align",
-                    "fa_icon": "fas fa-align-center"
                 }
             },
             "fa_icon": "fas fa-filter"
@@ -156,6 +151,11 @@
                     "default": 5,
                     "description": "Reads with an apparent depth of under nx will be presumed to be errors and discarded",
                     "fa_icon": "fas fa-align-justify"
+                },
+                "save_bbnorm_fastq": {
+                    "type": "boolean",
+                    "description": "save the resulting fastq files from normalization",
+                    "fa_icon": "fas fa-align-center"
                 }
             }
         },
@@ -181,6 +181,20 @@
                 }
             },
             "fa_icon": "fas fa-bezier-curve"
+        },
+        "mapping_options": {
+            "title": "Mapping options",
+            "type": "object",
+            "description": "",
+            "default": "",
+            "properties": {
+                "save_bam": {
+                    "type": "boolean",
+                    "description": "save the bam files from mapping",
+                    "fa_icon": "fas fa-align-center"
+                }
+            },
+            "fa_icon": "fas fa-filter"
         },
         "orf_caller_options": {
             "title": "Orf Caller options",
@@ -292,9 +306,8 @@
                 },
                 "cat_db": {
                     "type": "string",
-                    "default": "None",
                     "description": "path to cat database",
-                    "help_text": "This parameter is mutual exclusive with \u00b4cat_db_generate\u00b4. You need to provide a version of CAT database that has the same DIAMOND version of the module (DIAMOND 2.0.8) otherwise you might encounter issues of incompatibility and the module will fail. We recommend to always use the database provided by CAT website: https://tbb.bio.uu.nl/bastiaan/CAT_prepare/",
+                    "help_text": "This parameter is mutually exclusive with \u00b4cat_db_generate\u00b4. You need to provide a version of CAT database that has the same DIAMOND version of the module (DIAMOND 2.0.8) otherwise you might encounter issues of incompatibility and the module will fail. We recommend to always use the database provided by CAT website: https://tbb.bio.uu.nl/bastiaan/CAT_prepare/",
                     "fa_icon": "fas fa-database"
                 },
                 "cat_db_generate": {
@@ -535,6 +548,9 @@
         },
         {
             "$ref": "#/definitions/assembler_options"
+        },
+        {
+            "$ref": "#/definitions/mapping_options"
         },
         {
             "$ref": "#/definitions/orf_caller_options"

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -147,6 +147,7 @@ include { BBMAP_BBNORM                               } from '../modules/nf-core/
 include { SEQTK_MERGEPE                              } from '../modules/nf-core/seqtk/mergepe/main'
 include { SUBREAD_FEATURECOUNTS as FEATURECOUNTS_CDS } from '../modules/nf-core/subread/featurecounts/main'
 include { SPADES                                     } from '../modules/nf-core/spades/main'
+include { SEQTK_SEQ as SEQTK_SEQ_CONTIG_FILTER       } from '../modules/nf-core/seqtk/seq/main'
 include { CAT_FASTQ            	                     } from '../modules/nf-core/cat/fastq/main'
 include { FASTQC                                     } from '../modules/nf-core/fastqc/main'
 include { MULTIQC                                    } from '../modules/nf-core/multiqc/main'
@@ -336,6 +337,12 @@ workflow METATDENOVO {
             .map { [ [ id: 'megahit' ], it ] }
             .set { ch_assembly_contigs }
         ch_versions = ch_versions.mix(MEGAHIT_INTERLEAVED.out.versions)
+    }
+
+    // If the user asked for length filtering, perform that with SEQTK_SEQ (the actual length parameter is used in modules.config)
+    if ( params.min_contig_length > 0 ) {
+        SEQTK_SEQ_CONTIG_FILTER ( ch_assembly_contigs )
+        ch_assembly_contigs = SEQTK_SEQ_CONTIG_FILTER.out.fastx
     }
 
     //


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

I added length filtering of contigs determinded by the new parameter `--min_contig_length`. The primary purpose is to filter RNASpades contigs at 200 just like Megahit contigs automatically are, but any other length can of course be specified. In fact, any filtering supported by seqtk seq can be applied as the actual filtering is determined in `nextflow.config`. To get the module called, one has to make sure the parameter is set > 0 though.

I also tidied up some other params.