### PR TITLE
multiqc report printed in results/multiqc

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -381,11 +381,7 @@ process {
         publishDir = [
             path: "${params.outdir}/multiqc",
             mode: 'copy',
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-            path: "${params.outdir}/summary_tables",
-            mode: 'copy',
-            pattern: '*.html',
-            saveAs: { filename -> "${params.assembler}.${params.orf_caller}.multiqc_report.html" }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 }


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

as the title says, multiqc is printing the output in the right results directory