### PR TITLE
Rearranged channels so user_orfs gets into file names

### DIFF
--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -22,9 +22,9 @@ WorkflowMetatdenovo.initialise(params, log)
 if ( params.gff && params.protein_fasta ) {
     orf_caller = 'user_orfs'
 } else if ( params.gff && ! params.protein_fasta ) {
-    exit 1, 'When supplying ORFs, both --gff and --protein_fasta must be speciefied, --protein_fasta file is missing!'
+    exit 1, 'When supplying ORFs, both --gff and --protein_fasta must be specified, --protein_fasta file is missing!'
 } else if ( params.protein_fasta && ! params.gff ) {
-    exit 1, 'When supplying ORFs, both --gff and --protein_fasta must be speciefied, --gff file is missing!'
+    exit 1, 'When supplying ORFs, both --gff and --protein_fasta must be specified, --gff file is missing!'
 } else {
     orf_caller = params.orf_caller
 }


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Several output files didn't get `user_orfs` in their names when `--gff` and `--protein_fasta` was specified.

Update: Did the same for user supplied `--assembly`.